### PR TITLE
Topic/enable manual workflow starts

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -12,6 +12,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '24 8 * * 0'
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -16,7 +16,8 @@ on:
     branches: [ master ]
   schedule:
     - cron: '15 3 * * 0'
-    
+  workflow_dispatch:
+  
 jobs:
   build:
     name: PSScriptAnalyzer


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to allow manual triggering of the workflows. The most important changes include adding `workflow_dispatch` to the `devskim.yml` and `powershell.yml` workflow files.

Changes to GitHub Actions workflows:

* [`.github/workflows/devskim.yml`](diffhunk://#diff-cf9c7e0ae50cd2d73f48fc95d5f4784c87b4932f23c9bf60f2223ef12262c4cdR15): Added `workflow_dispatch` to enable manual triggering of the workflow.
* [`.github/workflows/powershell.yml`](diffhunk://#diff-bb6713ae10b7bbbcd2478bd4e5943ba2958edc705aa71b142cff0bb77cfacfa4R19): Added `workflow_dispatch` to enable manual triggering of the workflow.